### PR TITLE
Optimize smpt dials

### DIFF
--- a/verifier/error.go
+++ b/verifier/error.go
@@ -75,7 +75,6 @@ func ParseSMTPError(err error) *LookupError {
 			"undeliverable",
 			"does not exist",
 			"may not exist",
-			"user unknown",
 			"user not found",
 			"invalid address",
 			"recipient invalid",
@@ -112,7 +111,8 @@ func ParseSMTPError(err error) *LookupError {
 				"blacklisted",
 				"blocked",
 				"block list",
-				"denied") {
+				"denied",
+				"user unknown") {
 				return newLookupError(ErrBlocked, errStr, true)
 			} else if insContains(errStr,
 				"SPF Sender",

--- a/verifier/error_test.go
+++ b/verifier/error_test.go
@@ -19,3 +19,10 @@ func TestParse550BlockedRCPTError(t *testing.T) {
 	assert.Equal(t, ErrBlocked, le.Message)
 	assert.Equal(t, err.Error(), le.Details)
 }
+
+func TestParse550UserUnkownRCPTError(t *testing.T) {
+	err := errors.New("550 5.1.1 User Unknown")
+	le := ParseSMTPError(err)
+	assert.Equal(t, ErrBlocked, le.Message)
+	assert.Equal(t, err.Error(), le.Details)
+}

--- a/verifier/verifier.go
+++ b/verifier/verifier.go
@@ -11,7 +11,7 @@ type Verifier struct {
 type Lookup struct {
 	Address
 	ValidFormat, Deliverable, FullInbox, HostExists, CatchAll, Disposable bool
-	ErrorDetails                                                     string
+	ErrorDetails                                                          string
 }
 
 // NewVerifier generates a new Verifier using the passed hostname and
@@ -66,6 +66,8 @@ func (v *Verifier) Verify(email string) (*Lookup, error) {
 				if le.Message == ErrFullInbox {
 					l.FullInbox = true // set FullInbox and return no error
 					return &l, nil
+				} else if le.Message == ErrBlocked {
+					return nil, le
 				}
 				return &l, le // Return if there's a true error
 			}


### PR DESCRIPTION
- Serially dialing each mx server only in case of error
- Return 500 in case of 'User Unknown'

[ch127376](https://app.clubhouse.io/fullcontact/story/127376/handle-additional-error-in-trumail)